### PR TITLE
Remove https:// from custom url pattern regex

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -244,11 +244,11 @@ var clockUpdate = () => {
                     } else {
                       data.patterns.forEach(pattern => {
                         if (!callName) {
-                          rgx = new RegExp('(https?://' + pattern + '[^>\\\\(\\n)]*)', 'g');
+                          rgx = new RegExp('(' + pattern + '[^>\\\\(\\n)]*)', 'g');
                           var patternCheck = rgx.exec(displayedEvents[i].DESCRIPTION);
                           if (patternCheck) {
                             callName = patternCheck[1].substr(patternCheck[1].lastIndexOf('/') + 1);
-                            callUrl = patternCheck[1];
+                            callUrl = 'http://' + patternCheck[1];
                           }
                         }
                       });


### PR DESCRIPTION
The regex pattern for finding custom urls like 'call.disqus.com' had 'https://' in it so the event description strings were not yielding any valid matches, which resulted in hangoutlooks creating a new call URL instead of using the provided. Also adds 'http://' to the callURL when the custom url pattern is found so that the meeting event href works.